### PR TITLE
NCIATWP-10373: regenerate server package-lock.json to match package.json overrides

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,7 +13,7 @@
         "compression": "^1.7.4",
         "express": "^4.17.1",
         "express-validator": "^7.2.1",
-        "express-xss-sanitizer": "^2.0.0",
+        "express-xss-sanitizer": "^2.0.2",
         "python-shell": "^5.0.0",
         "winston": "^3.3.3",
         "winston-daily-rotate-file": "^4.5.0"
@@ -620,10 +620,9 @@
       }
     },
     "node_modules/express-xss-sanitizer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/express-xss-sanitizer/-/express-xss-sanitizer-2.0.0.tgz",
-      "integrity": "sha512-C9ZBsm3NuLzUaq7oAtU5Yboj2BQZEuhXShT1/dtUddVSXLPWUxgbpAWvaoDJ2fWH35NBE+/Ardjty9lQofLS8g==",
-      "license": "MIT",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/express-xss-sanitizer/-/express-xss-sanitizer-2.0.2.tgz",
+      "integrity": "sha512-6SYfX7Q4jagOVuxaExf2J6geM79KQwzluCIEYLEkp0FN40HctzkMxgdyDE0bEDi3KMyQQMOP3nGUZqib5hb13w==",
       "dependencies": {
         "sanitize-html": "~2.13.0"
       }
@@ -1166,7 +1165,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1297,12 +1295,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "license": "BSD-3-Clause",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1508,14 +1506,13 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1527,13 +1524,12 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1546,7 +1542,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -1564,7 +1559,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -1709,12 +1703,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "license": "MIT",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validator": {


### PR DESCRIPTION
**Ticket:** [NCIATWP-10373](https://tracker.nci.nih.gov/browse/NCIATWP-10373)

## Summary
Regenerate `server/package-lock.json` so it matches the current `server/package.json` (and its `overrides`). The committed lock had drifted behind package.json:

| Package | Lock (before) | Lock (after) | Reason |
|---|---|---|---|
| qs | 6.13.0 | 6.15.3 | override `^6.15.2` — clears qs Medium **CVE-2026-8723** |
| uuid | 8.0.0 | 11.1.1 | override `^11.1.1` |
| express-xss-sanitizer | 2.0.0 | 2.0.2 | dep range `^2.0.2` |

Lock-only regeneration (`npm install --package-lock-only`); **package.json is unchanged**.

## Why
The deployed image was already unaffected — the backend Dockerfile uses `npm install`, which honors the `overrides` at build time (the qa Twistlock scan already shows `qs`=0). But the stale lock is a latent trap: it would reintroduce the CVEs — or fail outright — the day the build switches to a locked install (`npm ci`).

## Where to test
Container build + Twistlock scan; `qs` remains absent from the backend image.

## Other info
No application code changes — lockfile only (26 insertions / 29 deletions).